### PR TITLE
Fix CPU usage issue caused by timer and task leaks

### DIFF
--- a/Kiwi/Recorder.swift
+++ b/Kiwi/Recorder.swift
@@ -14,6 +14,7 @@ class Recorder: NSObject, ObservableObject, AVAudioRecorderDelegate {
     private let playbackController = PlaybackController.shared
     @Published var audioMeter = AudioMeter(averagePower: 0, peakPower: 0)
     private var audioLevelCheckTask: Task<Void, Never>?
+    private var audioMeterUpdateTask: Task<Void, Never>?
     private var hasDetectedAudioInCurrentSession = false
     
     enum RecorderError: Error {
@@ -110,9 +111,10 @@ class Recorder: NSObject, ObservableObject, AVAudioRecorderDelegate {
             }
             
             audioLevelCheckTask?.cancel()
+            audioMeterUpdateTask?.cancel()
             
-            Task {
-                while recorder != nil {
+            audioMeterUpdateTask = Task {
+                while recorder != nil && !Task.isCancelled {
                     updateAudioMeter()
                     try? await Task.sleep(nanoseconds: 33_000_000)
                 }
@@ -148,6 +150,9 @@ class Recorder: NSObject, ObservableObject, AVAudioRecorderDelegate {
     
     func stopRecording() {
         audioLevelCheckTask?.cancel()
+        audioLevelCheckTask = nil
+        audioMeterUpdateTask?.cancel()
+        audioMeterUpdateTask = nil
         recorder?.stop()
         recorder = nil
         audioMeter = AudioMeter(averagePower: 0, peakPower: 0)

--- a/Kiwi/Views/Recorder/RecorderComponents.swift
+++ b/Kiwi/Views/Recorder/RecorderComponents.swift
@@ -102,6 +102,7 @@ struct ProcessingIndicator: View {
 // MARK: - Progress Animation Component
 struct ProgressAnimation: View {
     @State private var currentDot = 0
+    @State private var timer: Timer?
     let animationSpeed: Double
     
     var body: some View {
@@ -113,10 +114,14 @@ struct ProgressAnimation: View {
             }
         }
         .onAppear {
-            Timer.scheduledTimer(withTimeInterval: animationSpeed, repeats: true) { _ in
+            timer = Timer.scheduledTimer(withTimeInterval: animationSpeed, repeats: true) { _ in
                 currentDot = (currentDot + 1) % 7
                 if currentDot >= 5 { currentDot = -1 }
             }
+        }
+        .onDisappear {
+            timer?.invalidate()
+            timer = nil
         }
     }
 }


### PR DESCRIPTION
## Problem
The application was consuming excessive CPU when left running, even when idle. This was caused by timer leaks that accumulated over time.

## Root Cause
1. **ProgressAnimation Timer Leak**: The `ProgressAnimation` view created a Timer on every appearance that ran 6-8 times per second but was never invalidated. Each transcription left a timer running forever, causing accumulation.
2. **Audio Meter Task**: The audio meter update task wasn't properly tracked for explicit cancellation.

## Changes
- **RecorderComponents.swift**: Added timer storage and proper cleanup with `.onDisappear` handler
- **Recorder.swift**: Added explicit task tracking and cancellation for audio meter updates

## Impact
- Before: Each transcription left a timer running forever (20 transcriptions = 120-160 timer callbacks per second)
- After: Timers and tasks properly cleaned up, CPU usage remains stable regardless of usage duration

## Testing
- Perform multiple transcriptions (10-20)
- Let the app sit idle
- CPU usage should now remain low instead of increasing over time